### PR TITLE
Bump mathlib

### DIFF
--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,8 +1,8 @@
 [package]
 name = "twist"
 version = "0.1"
-lean_version = "leanprover-community/lean:3.42.1"
+lean_version = "leanprover-community/lean:3.45.0"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "f13e5dfdaf7f8267bdeefd8fb168aafdd3ef6950"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "c0cc689babd41c0e9d5f02429211ffbe2403472a"}

--- a/src/MSpec/basic.lean
+++ b/src/MSpec/basic.lean
@@ -105,7 +105,7 @@ instance (U : (opens Spec.T)ᵒᵖ) (x : U.unop) :
 localized_module.is_module
 
 instance (U : (opens Spec.T)ᵒᵖ) :
-  has_scalar ((Spec.structure_sheaf R).1.obj U) ((MSpec.structure_sheaf M).1.obj U) :=
+  has_smul ((Spec.structure_sheaf R).1.obj U) ((MSpec.structure_sheaf M).1.obj U) :=
 { smul := λ r m, ⟨λ x, (r.1 x) • (m.1 x), λ x, begin
     rcases r.2 x with ⟨Vr, mem1, i1, ρ, s, hr⟩,
     rcases m.2 x with ⟨Vm, mem2, i2, m, t, ht⟩,

--- a/src/enough_injectives/adjunction_Ab.lean
+++ b/src/enough_injectives/adjunction_Ab.lean
@@ -92,7 +92,7 @@ namespace hom_equiv
 def forward (f : (forget₂ (Module.{v} R) Ab.{v}).obj M ⟶ A) :
   M ⟶ (coextension.functor R).obj A :=
 { to_fun := λ m, 
-  { to_fun := λ r, f (@has_scalar.smul R M _ r m),
+  { to_fun := λ r, f (@has_smul.smul R M _ r m),
     map_zero' := by rw [zero_smul, map_zero],
     map_add' := λ x y, by rw [add_smul, map_add] },
   map_add' := λ x y, begin
@@ -127,7 +127,7 @@ def unit :
   forget₂ (Module ↥R) Ab ⋙ coextension.functor R :=
 { app := λ M, 
   { to_fun := λ m, 
-    { to_fun := λ r, @has_scalar.smul R M _ r m,
+    { to_fun := λ r, @has_smul.smul R M _ r m,
       map_zero' := by rw [zero_smul],
       map_add' := λ x y, by rw [add_smul] },
     map_add' := λ x y, begin

--- a/src/enough_injectives/change_of_rings.lean
+++ b/src/enough_injectives/change_of_rings.lean
@@ -31,12 +31,12 @@ def is_module : _root_.module R N := (f ^* N).is_module
 localized "attribute [instance] restriction_of_scalars.is_module" in change_of_rings
 
 
-instance has_scalar' : _root_.has_scalar S (f ^* N) :=
-{ smul := λ s n, @has_scalar.smul S N _ s n }.
+instance has_scalar' : _root_.has_smul S (f ^* N) :=
+{ smul := λ s n, @has_smul.smul S N _ s n }.
 
 @[simp] lemma smul_def' (r : R) (n : f ^* N) : r • n = f r • n := rfl
 @[simp] lemma smul_def (r : R) (n : N) :
-  @has_scalar.smul R N begin
+  @has_smul.smul R N begin
     haveI := is_module f N,
     apply_instance,
   end r n = f r • n := rfl
@@ -193,7 +193,7 @@ end.
 Since `S` has an `R`-module structure, `M ⊗[R] S` can be given an `S`-module structure.
 The scalar multiplication is defined by `s • (m ⊗ s') := m ⊗ (s * s')`
 -/
-@[reducible] def has_scalar_S_M_tensor_S : _root_.has_scalar S (M ⊗[R, f] S) :=
+@[reducible] def has_scalar_S_M_tensor_S : _root_.has_smul S (M ⊗[R, f] S) :=
 { smul := λ s', smul_by f M s' }
 
 local attribute [instance] has_scalar_S_M_tensor_S

--- a/src/enough_injectives/divisible_group.lean
+++ b/src/enough_injectives/divisible_group.lean
@@ -211,6 +211,10 @@ instance [divisible A] : divisible (ulift A) :=
 
 local notation `ℚ⧸ℤ` := (ulift.{u} (ℚ ⧸ ℤ_as_ℚ_subgroup))
 local notation `I` := AddCommGroup.of A ⟶ AddCommGroup.of (ℚ⧸ℤ)
+
+@[reducible] def dummy_function : I → Type u := λ i, ℚ⧸ℤ
+instance : add_comm_group (Π (i : I), ℚ⧸ℤ) := @pi.add_comm_group I (dummy_function A) (λ _ , infer_instance)
+
 local notation `D` := AddCommGroup.of (Π (i : I), ℚ⧸ℤ)
 
 instance : category_theory.injective (⟨ℚ⧸ℤ⟩ : Module ℤ) := 
@@ -636,7 +640,7 @@ end
 
 def has_injective_presentation : category_theory.injective_presentation (AddCommGroup.of.{u} A) :=
 { J := D,
-  injective := injective_of_divisible _ $ divisible_of_product_divisible _,
+  injective := injective_of_divisible _ (by apply divisible_of_product_divisible), 
   f := embed_into_injective A,
   mono := (AddCommGroup.mono_iff_injective _).mpr $ embed_into_injective_injective _ }
 

--- a/src/grading/graded_module.lean
+++ b/src/grading/graded_module.lean
@@ -38,7 +38,7 @@ def decompose : M ≃+ ⨁ i, 𝓜 i := add_equiv.symm
 direct_sum.coe_add_monoid_hom_of _ _ _
 
 instance self : graded_module 𝓐 (λ i, (𝓐 i).to_add_submonoid) :=
-{ decompose' := graded_algebra.decompose 𝓐,
+{ decompose' := direct_sum.decompose 𝓐,
   left_inv := graded_algebra.left_inv,
   right_inv := graded_algebra.right_inv,
   smul_mem := λ i j x y hi hj, set_like.graded_monoid.mul_mem hi hj }
@@ -213,43 +213,43 @@ from λ x, (direct_sum.is_internal.add_submonoid_supr_eq_top _ (graded_module.is
   right_inv := λ x, add_submonoid.supr_induction 𝓜 (m x) (twisted_by.right_inv.mem 𝓐 𝓜 i) (by simp only [map_zero]) (λ _ _ hx hy, by simp only [map_add, hx, hy]),
   smul_mem := twisted_by.smul_mem' 𝓐 𝓜 i }
 
-instance internal.has_scalar (i : ι) : has_scalar A (⨁ j, twisted_by 𝓜 i j) :=
+instance internal.has_scalar (i : ι) : has_smul A (⨁ j, twisted_by 𝓜 i j) :=
 { smul := λ a z, graded_module.decompose 𝓐 (twisted_by 𝓜 i) (a • (graded_module.decompose 𝓐 (twisted_by 𝓜 i)).symm z) }
 
 lemma internal.one_smul (i : ι) (z : ⨁ j, twisted_by 𝓜 i j) :
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) (1 : A) z = z := 
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) (1 : A) z = z := 
 begin
   change graded_module.decompose _ _ _ = _,
   rw [one_smul, add_equiv.apply_symm_apply],
 end
 
 lemma internal.smul_add (i : ι) (a : A) (x y : ⨁ j, twisted_by 𝓜 i j) :
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a (x + y) = 
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a x +
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a y := 
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a (x + y) = 
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a x +
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a y := 
 begin
   change graded_module.decompose _ _ _ = graded_module.decompose _ _ _ + graded_module.decompose _ _ _,
   simp only [map_add, smul_add],
 end 
 
 lemma internal.smul_zero (i : ι) (a : A) :
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a 0 = 0 :=
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a 0 = 0 :=
 begin
   change graded_module.decompose _ _ _ = _,
   simp only [map_zero, smul_zero],
 end
 
 lemma internal.add_smul (i : ι) (a b : A) (x : ⨁ j, twisted_by 𝓜 i j) :
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) (a + b) x =
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a x +
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) b x :=
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) (a + b) x =
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a x +
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) b x :=
 begin
   change graded_module.decompose _ _ _ = graded_module.decompose _ _ _ + graded_module.decompose _ _ _,
   simp only [map_add, add_smul],
 end
 
 lemma internal.zero_smul (i : ι) (x : ⨁ j, twisted_by 𝓜 i j) :
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) 0 x = 0 :=
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) 0 x = 0 :=
 begin
   change graded_module.decompose _ _ _ = _,
   simp only [zero_smul, map_zero],
@@ -257,20 +257,20 @@ end
 
 lemma internal.mul_smul_of_of (i : ι) {j j' : ι} {a b : A} (hj : a ∈ 𝓐 j) (hj' : b ∈ 𝓐 j')
   (x : ⨁ j, twisted_by 𝓜 i j) :
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) (a * b) x = 
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a 
-    (@has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) b x) := 
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) (a * b) x = 
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a 
+    (@has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) b x) := 
 begin
   change graded_module.decompose _ _ _ = graded_module.decompose _ _ _,
-  unfold has_scalar.smul,
+  unfold has_smul.smul,
   rw add_equiv.symm_apply_apply,
   rw mul_smul,
 end
 
 lemma internal.mul_smul (i : ι) (a b : A) (x : ⨁ j, twisted_by 𝓜 i j) :
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) (a * b) x = 
-  @has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a 
-    (@has_scalar.smul _ _ (internal.has_scalar 𝓐 𝓜 i) b x) :=
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) (a * b) x = 
+  @has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) a 
+    (@has_smul.smul _ _ (internal.has_scalar 𝓐 𝓜 i) b x) :=
 have m : ∀ x, x ∈ supr 𝓐,
 from λ x, (graded_algebra.is_internal 𝓐).submodule_supr_eq_top.symm ▸ submodule.mem_top,
 begin
@@ -283,9 +283,9 @@ begin
       have := internal.mul_smul_of_of 𝓐 𝓜 i hj hj' x,
       change graded_module.decompose _ _ _ = graded_module.decompose _ _ _ at this,
       rwa [mul_smul] at this, },
-    { unfold has_scalar.smul,
+    { unfold has_smul.smul,
       simp only [zero_smul, map_zero, smul_zero], },
-    { unfold has_scalar.smul,
+    { unfold has_smul.smul,
       intros b c hb hc,
       simp only [smul_add, add_smul, hb, hc, map_add], }, },
   { simp only [smul_zero, zero_smul, map_zero], },

--- a/src/module_localisation/basic.lean
+++ b/src/module_localisation/basic.lean
@@ -206,7 +206,7 @@ lemma add_zero' (x : localized_module M S) : x + 0 = x :=
 induction_on (λ m s, by rw [← zero_mk s, mk_add_mk, smul_zero, add_zero, mk_eq];
   exact ⟨1, by rw [one_smul, mul_smul, one_smul]⟩) x
 
-instance has_nat_scalar : has_scalar ℕ (localized_module M S) :=
+instance has_nat_scalar : has_smul ℕ (localized_module M S) :=
 { smul := λ n, nat.rec_on n (λ x, 0) (λ m f x, x + f x) }
 
 lemma nsmul_zero' (x : localized_module M S) : (0 : ℕ) • x = 0 :=
@@ -226,7 +226,7 @@ instance : add_comm_monoid (localized_module M S) :=
   nsmul_succ' := nsmul_succ',
   add_comm := add_comm' }
 
-instance : has_scalar (localization S) (localized_module M S) :=
+instance : has_smul (localization S) (localized_module M S) :=
 { smul := λ f x, localization.lift_on f (λ r s, lift_on x (λ p, mk (r • p.1) (s * p.2))
     begin
       rintros ⟨m1, t1⟩ ⟨m2, t2⟩ ⟨u, h⟩,
@@ -261,7 +261,7 @@ instance : has_scalar (localization S) (localized_module M S) :=
 lemma mk_smul_mk (r : R) (m : M) (s t : S) :
   localization.mk r s • mk m t = mk (r • m) (s * t) :=
 begin
-  unfold has_scalar.smul,
+  unfold has_smul.smul,
   rw [localization.lift_on_mk, lift_on_mk],
 end
 


### PR DESCRIPTION
This PR stems from the conversation on Zulip about flat modules linked [here](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/flat.20modules) 

I'm hoping to make some progress on the problem by using the argument mentioned by Junyan Xu which relies on a few facts

* Baer's criterion for injectivity (merged in your [PR](https://github.com/leanprover-community/mathlib/pull/12895))
* Existence of injective cogenerators given enough injectives (currently an open PR [here](https://github.com/leanprover-community/mathlib/pull/15495))
* `Module R` has enough injectives, which is in this repository.

In order to bring all the different pieces into agreement I started bumping the mathlib dependencies for this repository. I am currently about 50% of the way there, modulo fixing a bunch of stuff that popped up from the `graded_algebra` refactor.

I don't know if you are strongly opposed to bumping the mathlib dependency on this repo, and I can use my fork if you are, but I figured I would open this draft PR in case it could be helpful (and ask for some hints on how to fix the outstanding issues).